### PR TITLE
Add add-on ID to manifest.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,5 +26,10 @@
                 "github-pr.js"
             ]
         }
-    ]
+    ],
+    "applications": {
+        "gecko": {
+            "id": "{ab950bab-858f-4d27-ad02-7d4b96e2430a}"
+        }
+    }
 }


### PR DESCRIPTION
When loading the add-on via about:debugging, you end up with two running copies of rob-bugson because the add-on ID is randomly generated. This fixes that by using the add-on ID AMO generated for the add-on as the permanent add-on ID.