### PR TITLE
Fix attaching github issue to page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.3 (September 13th, 2018)
+
+* bug: Update addon to work with BMO changes. (#12)
+
+
 ## v1.2 (October 27th, 2017)
 
 * bug: Implement a MutationObserver to handle pjax (#6)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ If you can help someone, please comment on their issue.
 I'll merge PRs and do releases, but probably won't do anything else.
 
 
+## Development
+
+Use the
+[browser extension docs on MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions).
+
+
 ## Acknowledgements
 
-This is inspired by Dietrich
-Ayala's
+This is inspired by Dietrich Ayala's
 [Github-Bugzilla-Tweaks](https://github.com/autonome/Github-Bugzilla-Tweaks).
 Thank you!
 

--- a/github-pr-background.js
+++ b/github-pr-background.js
@@ -36,8 +36,8 @@ async function getActiveTab() {
 
 
 /**
- * Creates a new tab related to the currently active tab, open the
- * Bugzilla attach url, and populate the fields.
+ * Creates a new tab related to the currently active tab, open the Bugzilla
+ * attach url, and populate the fields.
  */
 async function createAttachTab(msg) {
     const tab = await getActiveTab();
@@ -53,19 +53,21 @@ async function createAttachTab(msg) {
     var attValue = sanitizeForTemplate(msg.prURL);
     var descValue = sanitizeForTemplate("pr " + msg.prNum + ": " + msg.prTitle);
 
-    // We need to add values for this specific attachment, so we
-    // build the template with local values and then execute the
-    // code in the tab.
+    // We need to add values for this specific attachment, so we build the
+    // template with local values and then execute the code in the tab.
     var attachScript = `
-        // switch from upload-file to paste-text attachment
-        if (document.querySelector(".attachment_text_field.bz_tui_hidden")) {
-            document.getElementById("attachment_data_controller").click();
-        }
-
-        let att = document.getElementById("attach_text");
-        let desc = document.getElementById("description");
+        // Add PR link
+        let att = document.getElementById("att-textarea");
         att.value = "${attValue}";
-        desc.value = "${descValue}";
+        // Trigger an input event so the textarea input handling kicks off.
+        var input_event = new Event('input', {
+            bubbles: true,
+            cancelable: true
+        });
+        att.dispatchEvent(input_event);
+        // Stomp on description with the PR title
+        let att_desc = document.getElementById("att-description");
+        att_desc.value = "${descValue}";
         att.focus();
     `;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "rob-bugson",
-    "version": "1.2",
+    "version": "1.3",
     "description": "Add 'Attach to bug' link to Bugzilla for GitHub pull requests.",
     "homepage_url": "https://github.com/willkg/rob-bugson",
     "icons": {


### PR DESCRIPTION
BMO changed their attachment form so it no longer has that toggle. This
updates rob-bugson to work with the new page.

Fixes #12 