### PR TITLE
Fix merge detection

### DIFF
--- a/github-bugzilla-content.js
+++ b/github-bugzilla-content.js
@@ -287,7 +287,7 @@ function addMergeLinks() {
     }
 
     // See if there's been a merge
-    let state = document.querySelector('div.State.State--purple');
+    let state = document.querySelector('.State.State--purple');
     if (state === null) {
         return;
     }


### PR DESCRIPTION
GitHub switched the div to a span. This nixes the tag in the selector
altogether.

Fixes #21.