### PR TITLE
Update "Merged" badge selector (#26)

### DIFF
--- a/github-bugzilla-content.js
+++ b/github-bugzilla-content.js
@@ -287,7 +287,7 @@ function addMergeLinks() {
     }
 
     // See if there's been a merge
-    let state = document.querySelector('.State.State--purple');
+    let state = document.querySelector('.State.State--merged');
     if (state === null) {
         return;
     }


### PR DESCRIPTION
GitHub changed the "Merged" badge classes, so this updates the selector
we use to find it.

Fixes #26.