### PR TITLE
Iterate through all links to find the one pointing to a commit

### DIFF
--- a/github-bugzilla-content.js
+++ b/github-bugzilla-content.js
@@ -341,9 +341,14 @@ function addMergeLinks(pageKind, prNum, prTitle, prUrl, prState, bugIds) {
 
             // NOTE(willkg): the a tag we want is the one that has no id or class--that"s
             // really irritating
-            let commitElem = el.querySelector("a:not([class])");
-            commitUrl = "https://github.com" + commitElem.getAttribute("href");
-            commitSha = commitElem.textContent.trim();
+            let linkElems = el.querySelectorAll("a");
+            Array.prototype.forEach.call(linkElems, (elem) => {
+                let href = elem.getAttribute("href")
+                if (href && href.match(/\/commit\//)) {
+                    commitUrl = "https://github.com" + href;
+                    commitSha = elem.textContent.trim();
+                }
+            });
         }
     });
 


### PR DESCRIPTION
The Refined GitHub adds a class to a link, thus rob-bugson won't find it
anymore and thus can't add the "add merge comment to bug" link.

So now instead of looking for the exact HTML element we look for a link
within the div that points to a commit (a URL that contains "/commit/")
and take that.

Fixes #32