### PR TITLE
Remove # from prURL value (#38)

### DIFF
--- a/github-bugzilla-content.js
+++ b/github-bugzilla-content.js
@@ -58,7 +58,11 @@ function getPRTitle() {
  * Retrieve the PR url
  */
 function getPRUrl() {
-    return document.URL;
+    let url = document.URL;
+    if (url.indexOf("#") != -1) {
+        url = url.substring(0, url.indexOf("#"));
+    }
+    return url;
 }
 
 

--- a/github-bugzilla-content.js
+++ b/github-bugzilla-content.js
@@ -55,19 +55,18 @@ function getPRTitle() {
 
 
 /**
- * Retrieve the PR url
+ * Retrieve the PR url.
+ *
+ * Make sure to drop # and anything after it because it makes Bugzilla sad.
  */
 function getPRUrl() {
     let url = document.URL;
-    if (url.indexOf("#") != -1) {
-        url = url.substring(0, url.indexOf("#"));
-    }
-    return url;
+    return url.replace(/#.*/, "");
 }
 
 
 /**
- * Retrieve PR state
+ * Retrieve PR state.
  */
 function getPRState() {
     // See if there"s been a merge
@@ -100,7 +99,7 @@ function getSelectedTab() {
 
 
 /**
- * Get list of bug ids from PR title
+ * Get list of bug ids from PR title.
  */
 function getBugIdsFromPRTitle(text) {
     let match = BUG_RE.exec(text);
@@ -114,7 +113,7 @@ function getBugIdsFromPRTitle(text) {
 }
 
 /**
- * Get list of bug ids from commits
+ * Get list of bug ids from commits.
  */
 function getBugIdsFromCommits() {
     let bugIds = [];


### PR DESCRIPTION
Sometimes the url has a # at the end and when rob-bugson uses that to attach the pr to a Bugzilla bug, it causes Bugzilla to attach the pr as a text/plain and then everything goes sideways.

This fixes getPRUrl to remove # if it's there.

To test:

1. pick a PR that has a corresponding bug like this one: https://github.com/mozilla-services/socorro-submitter/pull/46
2. in the url bar, add a `#` and hard-refresh the page
3. click on the link to attach the PR

Before this fix, Bugzilla attaches the PR wrong. After this fix, Bugzilla attaches the PR correctly.

Fixes #38.