### PR TITLE
support Bugzilla merge comment URLs for merge queues

### DIFF
--- a/content.test.js
+++ b/content.test.js
@@ -1,6 +1,10 @@
 const {
+    addMergeLinks,
+    BUG_BASE_URL,
     getAttachLinks,
     getBugIdsFromPRTitle,
+    MERGE_CONTAINER_ID,
+    PR_STATE_MERGED,
 } = require("./github-bugzilla-content");
 
 describe("Content script", () => {
@@ -48,4 +52,84 @@ describe("Content script", () => {
             },
         );
     });
+
+    describe("addMergeLinks", () => {
+        const pageKind = "pr"
+        const repoInfo = {
+            repoName: "socorro",
+            repoOrg: "mozilla-services"
+        };
+        const prNum = "99"
+        const prTitle = "bug-1: wow impressive title";
+        const prUrl = "https://github.com/mozilla-services/socorro/pull/99"
+        const prState = PR_STATE_MERGED;
+        const bugIds = [1]
+
+        const author = "Scrooge McDuck"
+        const fullCommitSha = "649428ff86e73ef7f6eefb730b8c55e717212d02"
+        const commitSha = fullCommitSha.substring(0, 6);
+        const commitUrl = `/mozilla-services/socorro/commit/${fullCommitSha}`
+
+        const expectedMessage = {
+            "eventName": "mergeComment",
+            "bugUrl": BUG_BASE_URL + bugIds[0],
+            "author": author,
+            "repoOrg": repoInfo.repoOrg,
+            "repoName": repoInfo.repoName,
+            "prNum": prNum,
+            "prUrl": prUrl,
+            "prTitle": prTitle,
+            "authorUrl": "https://github.com/" + author,
+            "commitSha": commitSha,
+            "commitUrl": "https://github.com" + commitUrl
+        };
+
+        it("sends a message to the background script when the merge link is clicked when a PR is merged manually by a user", () => {
+            const sendMessage = jest.spyOn(browser.runtime, "sendMessage").mockResolvedValue({});
+
+            // Mock the HTML structure
+            document.body.innerHTML = `
+                <div class="gh-header-show">
+                    <div id="${MERGE_CONTAINER_ID}">
+                    </div>
+                </div>
+                <div class="TimelineItem">
+                    <div class="TimelineItem-body">
+                        <a class="author" href="/${author}">${author}</a> merged commit <a href="/mozilla-services/socorro/commit/${fullCommitSha}">${commitSha}</a>into main
+                    </div>
+                </div>
+            `;
+            addMergeLinks(pageKind, repoInfo, prNum, prTitle, prUrl, prState, bugIds);
+            const linkContainer = document.getElementById(MERGE_CONTAINER_ID);
+            const mergeLinkEle = linkContainer.querySelector("a.merge_link");
+            mergeLinkEle.click();
+            expect(sendMessage).toHaveBeenCalledWith(expectedMessage);
+        })
+
+        it("sends a message to the background script when the merge link is clicked when a PR is merged via a merge queue", () => {
+            const sendMessage = jest.spyOn(browser.runtime, "sendMessage").mockResolvedValue({});
+            
+            // Mock the HTML structure
+            document.body.innerHTML = `
+                <div class="gh-header-show">
+                    <div id="${MERGE_CONTAINER_ID}">
+                    </div>
+                </div>
+                <div class="TimelineItem">
+                    <div class="TimelineItem-body">
+                        <a class="author" href="/${author}">${author}</a>
+                        added this pull request to the <a href="/mozilla-services/socorro/queue/main" class="Link">merge queue</a>
+                    </div>
+                    <div class="TimelineItem-body">
+                        Merged via the queue into main with commit <a href=${commitUrl}>${commitSha}</a>
+                    </div>
+                </div>
+            `;
+            addMergeLinks(pageKind, repoInfo, prNum, prTitle, prUrl, prState, bugIds);
+            const linkContainer = document.getElementById(MERGE_CONTAINER_ID);
+            const mergeLinkEle = linkContainer.querySelector("a.merge_link");
+            mergeLinkEle.click();
+            expect(sendMessage).toHaveBeenCalledWith(expectedMessage);
+        });
+    })
   });

--- a/github-bugzilla-content.js
+++ b/github-bugzilla-content.js
@@ -355,8 +355,17 @@ function addMergeLinks(pageKind, repoInfo, prNum, prTitle, prUrl, prState, bugId
 
     // This goes through all the events to figure out the merge commit
     Array.prototype.forEach.call(elements, (el) => {
-        if (el.textContent.match(/merged commit/)) {
-            author = el.querySelector("a.author").textContent.trim();
+        if (
+            el.textContent.match(/merged commit/) ||
+            // For PRs merged via a merge queue, we need two different events,
+            // since there isn't a single event that has both the GitHub username
+            // and the commit hash.
+            el.textContent.match(/added this pull request to the merge queue/) ||
+            el.textContent.match(/via the queue/)
+        ) {
+            if (!author) {
+                author = el.querySelector("a.author").textContent.trim();
+            } 
 
             // NOTE(willkg): the a tag we want is the one that has no id or class--that"s
             // really irritating
@@ -498,6 +507,10 @@ if (pjaxContainer) {
 }
 
 module.exports = {
+    addMergeLinks,
+    BUG_BASE_URL,
     getAttachLinks,
     getBugIdsFromPRTitle,
+    MERGE_CONTAINER_ID,
+    PR_STATE_MERGED,
 }


### PR DESCRIPTION
Fixes #65 

The main thing is we actually need info from two different GitHub PR event elements for merge queues, since there isn't a single merge-related event that includes both the author and the commit hash as with PRs that are manually merged by a user.

In particular, we need these two events for example:
"[relud](https://github.com/relud) added this pull request to the [merge queue](https://github.com/mozilla-services/socorro/queue/main) yesterday" AND
"Merged via the queue into main with commit [649428f](https://github.com/mozilla-services/socorro/commit/649428ff86e73ef7f6eefb730b8c55e717212d02) [yesterday](https://github.com/mozilla-services/socorro/pull/6733#event-14388752338)"

Whereas for a manual merge by a user, we just need this event:
"[biancadanforth](https://github.com/biancadanforth) merged commit [7ff1b0e](https://github.com/mozilla-services/socorro/commit/7ff1b0e1e43efe4bec0a0e453ed7b4913c190b5e) into main [5 days ago](https://github.com/mozilla-services/socorro/pull/6728#event-14346238424)"